### PR TITLE
feat : 메인 셰프 리스트

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,12 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-	images: {
-		domains: [
-			"ugc-images.catchtable.co.kr",
-			"encrypted-tbn0.gstatic.com",
-			"mjhcmaqftsbfevquhyqc.supabase.co",
-		]
-	},
+  //   reactStrictMode: false,
+  images: {
+    domains: ["ugc-images.catchtable.co.kr", "encrypted-tbn0.gstatic.com", "mjhcmaqftsbfevquhyqc.supabase.co"]
+  }
 };
 
 export default nextConfig;

--- a/src/app/components/mainPage/CategoryButton.tsx
+++ b/src/app/components/mainPage/CategoryButton.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+type CategoryButtonPropsType = {
+  buttonType: string;
+  category: string;
+  onClick: (buttonType: string) => void;
+};
+
+const CategoryButton = ({ buttonType, category, onClick }: CategoryButtonPropsType) => {
+  return (
+    <button
+      className={`size-full h-12 ${category === buttonType ? "bg-white text-black" : "bg-black text-white"}`}
+      onClick={() => onClick(buttonType)}
+    >
+      {buttonType}
+    </button>
+  );
+};
+
+export default CategoryButton;

--- a/src/app/components/mainPage/ChefInfo.tsx
+++ b/src/app/components/mainPage/ChefInfo.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { Chefs } from "../../../types/info";
+import Image from "next/image";
+import Link from "next/link";
+import RestaurantInfo from "./RestaurantInfo";
+
+const ChefInfo = ({ chef }: { chef: Chefs[] }) => {
+  return (
+    <ul className="flex flex-wrap justify-center gap-5">
+      {chef?.map((c: Chefs) => {
+        return (
+          <li key={c.id} className="pb-10">
+            <Link href={`/${c.chef_name}`}>
+              <Image
+                src={
+                  c.chef_img_url ??
+                  "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQ8-VorlNYtHd0lxv9dRjs7a9PKdWuEEkXkbg&s"
+                }
+                alt={c.chef_name}
+                width={500}
+                height={300}
+              />
+            </Link>
+
+            <RestaurantInfo restaurant={c.restaurant[0]} chefName={c.chef_name} />
+          </li>
+        );
+      })}
+    </ul>
+  );
+};
+
+export default ChefInfo;

--- a/src/app/components/mainPage/ChefList.tsx
+++ b/src/app/components/mainPage/ChefList.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+import { supabase } from "@/lib/supabaseClient";
+import ChefInfo from "./ChefInfo";
+import CategoryButton from "./CategoryButton";
+import { Chefs } from "../../../types/info";
+
+const ChefList = () => {
+  const [category, setCategory] = useState("백수저");
+  const [whiteChef, setWhiteChef] = useState<Chefs[]>([]);
+  const [blackChef, setBlackChef] = useState<Chefs[]>([]);
+
+  const whiteScrollRef = useRef<HTMLHeadingElement | null>(null); // 백수저 ref
+  const blackScrollRef = useRef<HTMLHeadingElement | null>(null); // 흑수저 ref
+
+  useEffect(() => {
+    const getChefs = async () => {
+      const { data, error } = await supabase.from("chef").select("*, restaurant(*)");
+
+      if (error) {
+        console.error("Error:", error.message);
+        throw new Error("데이터를 가져오는 데 실패했습니다.");
+      }
+
+      if (data) {
+        const whiteChefs = data.filter((chef: Chefs) => chef.chef_class === "white");
+        const blackChefs = data.filter((chef: Chefs) => chef.chef_class === "black");
+        setWhiteChef(whiteChefs);
+        setBlackChef(blackChefs);
+      }
+    };
+    getChefs();
+  }, []);
+
+  const handleMoveScroll = (buttonType: string) => {
+    setCategory(buttonType);
+
+    if (buttonType === "백수저") {
+      whiteScrollRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+    } else if (buttonType === "흑수저") {
+      blackScrollRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  };
+
+  return (
+    <div>
+      <section className="flex justify-around mb-8">
+        <CategoryButton onClick={handleMoveScroll} buttonType={"백수저"} category={category} />
+        <CategoryButton onClick={handleMoveScroll} buttonType={"흑수저"} category={category} />
+      </section>
+      <section>
+        <h2 className="text-2xl font-bold text-center mb-4" ref={whiteScrollRef}>
+          백수저
+        </h2>
+        <ChefInfo chef={whiteChef} />
+
+        <h2 className="text-2xl font-bold text-center mb-4" ref={blackScrollRef}>
+          흑수저
+        </h2>
+        <ChefInfo chef={blackChef} />
+      </section>
+    </div>
+  );
+};
+
+export default ChefList;

--- a/src/app/components/mainPage/MainImage.tsx
+++ b/src/app/components/mainPage/MainImage.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import React from "react";
+import Image from "next/image";
+
+// 임시
+const mainImage = [
+  "https://mjhcmaqftsbfevquhyqc.supabase.co/storage/v1/object/sign/culinary-class-wars-image/main-2.jpg?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1cmwiOiJjdWxpbmFyeS1jbGFzcy13YXJzLWltYWdlL21haW4tMi5qcGciLCJpYXQiOjE3Mjg4ODk0MjAsImV4cCI6MjA0NDI0OTQyMH0.3jJIRvKZvs4lO0ALKS4UCnefW11CfQb-i-dj9ObjhyI",
+  "https://mjhcmaqftsbfevquhyqc.supabase.co/storage/v1/object/public/culinary-class-wars-image/main-3.jpg",
+  "https://mjhcmaqftsbfevquhyqc.supabase.co/storage/v1/object/public/culinary-class-wars-image/main-4.png",
+  "https://mjhcmaqftsbfevquhyqc.supabase.co/storage/v1/object/sign/culinary-class-wars-image/main-1.png?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1cmwiOiJjdWxpbmFyeS1jbGFzcy13YXJzLWltYWdlL21haW4tMS5wbmciLCJpYXQiOjE3Mjg4ODk0MTcsImV4cCI6MjA0NDI0OTQxN30.RuDH_xiIWHbCPsoB2UUiFl1FBsjpHKcgnB-Ml8OfKRo"
+];
+
+const MainImage = () => {
+  return (
+    <div>
+      상단 이미지
+      {/* <Image src={mainImage[0]} alt={"메인 이미지"} width={100} height={100} layout="responsive" /> */}
+      {/* {mainImage.map((image) => {
+        return (
+          <div key={image} style={{ width: "100vw" }}>
+            <Image src={image} alt={"메인 이미지"} width={500} height={500} />
+          </div>
+        );
+      })} */}
+    </div>
+  );
+};
+
+export default MainImage;

--- a/src/app/components/mainPage/RestaurantInfo.tsx
+++ b/src/app/components/mainPage/RestaurantInfo.tsx
@@ -1,0 +1,35 @@
+import { Restaurant } from "@/types/info";
+import Image from "next/image";
+import React from "react";
+
+type RestaurantPropsType = {
+  restaurant: Restaurant;
+  chefName: string;
+};
+
+const RestaurantInfo = ({ restaurant, chefName }: RestaurantPropsType) => {
+  return (
+    <div className="px-7 ">
+      <div className="flex bg-stone-200	">
+        <Image
+          src={
+            restaurant?.restaurant_img_url ??
+            "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQ8-VorlNYtHd0lxv9dRjs7a9PKdWuEEkXkbg&s"
+          }
+          alt={chefName}
+          width={60}
+          height={60}
+        />
+        <div className="flex flex-col">
+          <div className="flex justify-between">
+            <h2 className="font-bold">{restaurant?.restaurant_name}</h2>
+            <p className="font-bold">⭐{restaurant?.star}</p>
+          </div>
+          <p className="text-sm font-light">{restaurant?.description ?? "정보 없음"}</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RestaurantInfo;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -35,7 +35,7 @@ export default function RootLayout({
         <ReactQueryProviders>
           <Script src={KAKAO_API_URL} strategy="beforeInteractive" />
           <Header />
-          <div className="mt-[56px]">{children}</div>
+          <main className="mt-[56px]">{children}</main>
         </ReactQueryProviders>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,13 @@
-import Image from "next/image";
+import MainImage from "./components/mainPage/MainImage";
+import ChefList from "./components/mainPage/ChefList";
 
-export default function Home() {
+async function Home() {
   return (
-    <div className="text-center pt-10">
-    <h1 className="text-3xl font-bold mb-4">흑백 요리사 : 쉐프님들의 가게</h1>
-
-    <p className="text-gray-500">
-      처음 진입 시 화면입니다. 메인 화면입니다.
-    </p>
-  </div>
+    <div>
+      <MainImage />
+      <ChefList />
+    </div>
   );
 }
+
+export default Home;

--- a/src/types/info.d.ts
+++ b/src/types/info.d.ts
@@ -1,40 +1,44 @@
 export type User = {
-	created_at: string;
-	id: string;
-	profile_img: string | null;
-	updated_at: string | null;
-	user_email: string | null;
-	user_name: string | null;
+  created_at: string;
+  id: string;
+  profile_img: string | null;
+  updated_at: string | null;
+  user_email: string | null;
+  user_name: string | null;
 };
 export type Chef = {
-	chef_class: string | null;
-	chef_img_url: string | null;
-	chef_name: string;
-	created_at: string;
-	description: string | null;
-	id: string;
+  chef_class: string | null;
+  chef_img_url: string | null;
+  chef_name: string;
+  created_at: string;
+  description: string | null;
+  id: string;
 };
 export type Restaurant = {
-	id: string;
-	restaurant_name: string;
-	address: string | null;
-	description: string | null;
-	latitude: string | null;
-	longitude: string | null;
-	star: number | null;
-	restaurant_img_url: string | null;
+  id: string;
+  restaurant_name: string;
+  address: string | null;
+  description: string | null;
+  latitude: string | null;
+  longitude: string | null;
+  star: number | null;
+  restaurant_img_url: string | null;
 };
 export type Bookmark = {
-	id: number;
-	restaurant_id: string | null;
-	user_id: string | null;
+  id: number;
+  restaurant_id: string | null;
+  user_id: string | null;
 };
 
 export type Review = {
-	id: string;
-	restaurant_id: string | null;
-	review_content: string | null;
-	star: number | null;
-	user_id: string | null;
-	created_at: string | null;
+  id: string;
+  restaurant_id: string | null;
+  review_content: string | null;
+  star: number | null;
+  user_id: string | null;
+  created_at: string | null;
+};
+
+export type Chefs = Chef & {
+  restaurant: Restaurant[];
 };


### PR DESCRIPTION
## 💁🏻‍♀️ 작업

-   메인페이지 하단 셰프 목록

<br>

## 🔥 작업 세부 내용

- 메인페이지 셰프 목록 조회
- 백수저, 흑수저 클릭하면 해당 영역으로 이동
- 클릭 시 셰프 상세 페이지로 이동

<br>

## 🚫 참고 사항

- 상단 이미지 작업 예정
- CSS 추가 작업 필요
- 모든 셰프의 모양새?을 맞추기 위해서 메인의 셰프 카드에서 셰프의 식당 정보를 모두 1개만 불러오도록 함(몇개 불러올지는 고민필요)
  
